### PR TITLE
Use existing Mura Scope ($) rather than instantiating a new one

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -120,7 +120,12 @@ component persistent="false" accessors="true" output="false" extends="includes.f
 		};
 
 		if ( !StructKeyExists(request.context, '$') ) {
-			request.context.$ = application.serviceFactory.getBean('muraScope').init(session.siteid);
+			if( structKeyExists(request,"muraScope")) {
+				request.context.$ = request.muraScope;
+			}
+			else {
+				request.context.$ = application.serviceFactory.getBean('muraScope').init(session.siteid);	
+			}	
 		};
 
 		request.context.pc = application[variables.framework.applicationKey].pluginConfig;


### PR DESCRIPTION
By instantiating request.context.$, cfc display objects not see the current content bean ($.content()) and it adds overhead; using request.muraScope if it exists solves both issues
