### PR TITLE
Make sure plugins obey Mura logic for sessions

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -229,6 +229,12 @@ component persistent="false" accessors="true" output="false" extends="includes.f
 		return super.isFrameworkInitialized() && StructKeyExists(application[variables.framework.applicationKey], 'cache');
 	}
 
+	// ========================== Session State Handlers Passthrough To Mura ==========
+	public any function setupSession() {
+		var local = structNew();
+		include '../../config/appcfc/onSessionStart_include.cfm';
+	}
+	include '../../config/appcfc/onSessionEnd_method.cfm';
 	
 	// ========================== Errors & Missing Views ==========================
 


### PR DESCRIPTION
During the course of developing a plugin I discovered that in certain cases, onSessionStart() and onSessionEnd() did not seem to be called. After much investigation I determined that the following:

1) If your very first hit to the app is to "/plugins/pluginname/index.cfm", then the session gets created without encountering a proper Mura onSessionStart(), leading to errors in some conditions that are probably very specific to my application but may be encountered by others who are doing "fancy stuff" with Mura plugins.

2) If "/plugins/pluginname/index.cfm" was the most recent URL called before a session ended, Mura's onSessionEnd() would not be triggered since the plugin template's Application.cfc doesn't include it.

Both of these problems seem to be related to the fact that this plugin template shares an application name with Mura and the "most recent request" to any Application.cfc sharing that name defines the application's configuration.

The issue of Mura's onSessionEnd() event not firing has come up on the Mura email list a few times as well. I am not sure if this was the cause in those cases, but it's possible.

Also, a quick examination of the Mura admin's code reveals that it contains this exact same code.

Presumably this problem would also exist for onApplicationEnd() but Mura does not define this do I don't think it's actually an issue there.