### PR TITLE
Dynamic package instead of MuraFW1 hard-coded value

### DIFF
--- a/display_objects/app1/index.cfm
+++ b/display_objects/app1/index.cfm
@@ -10,5 +10,5 @@
 */
 
 include '../../config.fw1.cfm';
-WriteOutput(new MuraFW1.Application(variables.framework).doAction('app1:main.default'));
+WriteOutput( CreateObject( "#variables.framework.package#.Application" ).init( variables.framework ).doAction('app1:main.default') );
 </cfscript>


### PR DESCRIPTION
Per convo w/ Steve earlier today, he had MuraFW1 hard-coded as the package name because some versions of CF were complaining when it was dynamic. I think I tracked that down to something specific w/ the new() operator and how it was being used. I've swapped that out with CreateObject() which seems to play more nicely.  Tested this syntax on Railo, Lucee 4.5, 5, ACF 10 and 11. They all seem fine. (My CF2016 install is down at the moment.)